### PR TITLE
fixed NPE

### DIFF
--- a/src/main/java/org/octtech/bw/ByteWatcher.java
+++ b/src/main/java/org/octtech/bw/ByteWatcher.java
@@ -35,7 +35,7 @@ public class ByteWatcher {
   public static final Consumer<Thread> EMPTY = a -> { };
   public static final BiConsumer<Thread, Long> BI_EMPTY =
       (a, b) -> { };
-  private final Map<Thread, ByteWatcherSingleThread> ams;
+  private volatile Map<Thread, ByteWatcherSingleThread> ams;
   private volatile Consumer<Thread> threadCreated = EMPTY;
   private volatile Consumer<Thread> threadDied =
       EMPTY;
@@ -114,6 +114,10 @@ public class ByteWatcher {
   }
 
   private void checkThreads() {
+    if (ams==null) {
+      return;
+    }
+
     Set<Thread> oldThreads = ams.keySet();
     Set<Thread> newThreads = Thread.getAllStackTraces().keySet();
 


### PR DESCRIPTION
Hi, 
I found a NullPointerException in the ByteWatcher.checkThreads. My fix checks and returns if the variable ams is null. This is caused by the monitor thread being started and running before the ams variable is initialized in the ByteWatcher constructor.
Thanks for sharing and all the good stuff!
Cheers,
Sebastian 
